### PR TITLE
chore: update deployment workflow for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,32 +4,47 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  build:
-
+  deploy:
     runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 2 
-        
-    - name: Set up Node.js 24
-      uses: actions/setup-node@v4
-      with:
-        node-version: 24
-        cache: npm
-        
-    - name: Install dependencies
-      run: npm clean-install
-      
-    - name: Pre-Deploy
-      run: npm run build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "little-alchemist-2-cheats",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "little-alchemist-2-cheats",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "dependencies": {
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "little-alchemist-2-cheats",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "homepage": "https://manix84.github.io/little-alchemist-2-cheats",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This pull request updates the deployment workflow to use the latest GitHub Actions for deploying to GitHub Pages and makes a minor version bump in the `package.json`. The workflow is now more secure, uses official actions, and sets up concurrency and permissions for better deployment management.

**GitHub Actions workflow improvements:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R7-R50): Migrated deployment to use the official `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` actions, replacing the previous third-party `peaceiris/actions-gh-pages` action. This includes adding permissions, setting up deployment environment, and specifying concurrency for safer and more robust deployments.

**Build and deployment process changes:**

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R7-R50): Changed dependency installation from `npm clean-install` to `npm ci` for more reliable and faster installs in CI environments.

**Versioning:**

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Bumped the version from `1.15.0` to `1.15.1` to reflect the workflow and deployment updates.